### PR TITLE
change rubygems deploy key to a placeholder to be filled in during repo setup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ script:
 deploy:
   provider: rubygems
   api_key:
-    secure: J19rBhFsEYozDnd5nAqLVGldCJRsyT5//9ZqbbtLIxgnoNllEPA0Qq3X358zkjZ8b1L+JrnRjv+/WyXNrUkXMP0/YLgy5T1rG90HhGp2dqXacF20Tj/6so4y8S4WKv7Y3Kf4vdxQFlPPBOaYzhvDkeIQuPUBxjMHvpmvsrK3RPg=
+    secure: <encrypted rubygems deploy key>
   gem: sensu-plugins-skel
   on:
     tags: true


### PR DESCRIPTION
The key is unique per-repo and needs to be filled in when the repo is setup.