### PR TITLE
Update post-install message

### DIFF
--- a/sensu-plugins-skel.gemspec
+++ b/sensu-plugins-skel.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s| # rubocop:disable Metrics/BlockLength
                                'release_prerelease' => 'false' }
   s.name                   = 'sensu-plugins-skel'
   s.platform               = Gem::Platform::RUBY
-  s.post_install_message   = 'You can use the embedded Ruby by setting EMBEDDED_RUBY=true in /etc/default/sensu'
+  s.post_install_message   = 'Thank you for installing Sensu Plugins!'
   s.require_paths          = ['lib']
   s.required_ruby_version  = '>= 2.0.0'
   s.summary                = 'Sensu plugins for skel'


### PR DESCRIPTION
Addresses https://github.com/sensu-plugins/sensu-plugins-feature-requests/issues/32

EMBEDDED_RUBY=true has been the default since Sensu 0.21, released in
11/2015.

