### PR TITLE
travis builds should install the gem before testing if it's in it's path

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,9 +18,9 @@ notifications:
     on_success: change
     on_failure: always
 script:
-- bundle exec rake default
-- gem build sensu-plugins-skel.gemspec
-- gem install sensu-plugins-skel-*.gem
+  - gem build sensu-plugins-skel.gemspec
+  - gem install sensu-plugins-skel-*.gem
+  - bundle exec rake default
 deploy:
   provider: rubygems
   api_key:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 This CHANGELOG follows the format located [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)
 
-## Unreleased
+## [Unreleased]
 ### Added
 - Basic Skel to be used to make new plugin repo setup easier.
 - PR template
 - Rubocop config
+
+[Unreleased]: https://github.com/sensu-plugins/sensu-plugins-skel/compare/0b2d68b64a3d100c10da5e4cfce42206b9f22250...HEAD


### PR DESCRIPTION
some minor skel changes:
- change the order to install gems before testing if they are in `$PATH`.
- update changelog to have example diff links for `## [Unreleased]`

Signed-off-by: Ben Abrams <me@benabrams.it>

## Pull Request Checklist

**Is this in reference to an existing issue?**

#### General

- [ ] Update Changelog following the conventions laid out [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)

- [ ] Update README with any necessary configuration snippets

- [ ] Binstubs are created if needed

- [ ] RuboCop passes

- [ ] Existing tests pass

#### New Plugins

- [ ] Tests

- [ ] Add the plugin to the README

- [ ] Does it have a complete header as outlined [here](http://sensu-plugins.io/docs/developer_guidelines.html#coding-style)

#### Purpose
Make the tests actually for binstubs actually work in travis.
#### Known Compatibility Issues
none.