### PR TITLE
Sudo is deprecated

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
-sudo: true
 service: docker
 language: ruby
 cache:


### PR DESCRIPTION
See https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration#timeline---its-happening-fast for the announcement. 

The use of sudo is deprecated now, all builds always use a full VM.